### PR TITLE
Add Python 3.6, Drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zope.ramcache
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bin
 build
 develop-eggs
 parts
+.coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - pypy
+    # Force a newer PyPy on the old 'precise' CI image
+    # in order to install 'cryptography' needed for coveralls
+    # After September 2017 this should be the default and the version
+    # pin can be removed.
+    - pypy-5.6.0
     - pypy3.5-5.8.0
 install:
     - pip install -U pip setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,19 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
-    - pypy3
+    - pypy3.5-5.8.0
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - python setup.py -q test -q
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Drop support for ``python setup.py test``.
 
+- Test PyPy3 on Travis CI.
+
 2.1.0 (2014-12-29)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,18 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 2.2.0 (unreleased)
-------------------
+==================
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6.
+- Drop support for Python 2.6 and 3.3.
 
+- Drop support for ``python setup.py test``.
 
 2.1.0 (2014-12-29)
-------------------
+==================
 
 - Added support for PyPy.  (PyPy3 is pending release of a fix for:
   https://bitbucket.org/pypy/pypy/issue/1946)
@@ -21,7 +23,7 @@ Changes
 
 
 2.0.0 (2013-02-28)
-------------------
+==================
 
 - Add support for Python 3.3.
 
@@ -33,7 +35,6 @@ Changes
 - Remove outdated classifier / keywords.
 
 1.0 (2009-07-23)
-----------------
+================
 
 - Broke out the ram cache functionality from ``zope.app.cache``.
-

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
 
 recursive-include src *
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,32 @@
-``zope.ramcache``
-=================
+===================
+ ``zope.ramcache``
+===================
+
+
+.. image:: https://img.shields.io/pypi/v/zope.ramcache.svg
+        :target: https://pypi.python.org/pypi/zope.ramcache/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.ramcache.svg
+        :target: https://pypi.org/project/zope.ramcache/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.ramcache.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.ramcache
 
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.ramcache/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.ramcache?branch=master
+
+
 This package provides a RAM-based cache implementation for Zope.
+
+The class ``zope.ramcache.ram.RAMCache`` is a (persistent) object
+meant to be shared between threads. It implements
+``zope.ramcache.interfaces.ram.IRAMCache``, which provides a simple
+interface to cache information as well as defines a maximum number and
+age for cached entries.
+
+The cache is based on the idea of using arbitrary objects as keys,
+with the ability to associate additional information in the cache key
+for any given object. For example, it's possible to cache information
+for an object for multiple different users simultaneously.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -20,22 +20,12 @@ def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
         return f.read()
 
-def alltests():
-    import os
-    import sys
-    import unittest
-    # use the zope.testrunner machinery to find all the
-    # test suites we've put under ourselves
-    import zope.testrunner.find
-    import zope.testrunner.options
-    here = os.path.abspath(os.path.join(os.path.dirname(__file__), 'src'))
-    args = sys.argv[:]
-    defaults = ["--test-path", here]
-    options = zope.testrunner.options.get_options(args, defaults)
-    suites = list(zope.testrunner.find.find_suites(options))
-    return unittest.TestSuite(suites)
+TESTS_REQUIRE = [
+    'zope.testing',
+    'zope.testrunner',
+]
 
-setup(name = 'zope.ramcache',
+setup(name='zope.ramcache',
       version='2.2.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
@@ -44,9 +34,9 @@ setup(name = 'zope.ramcache',
           read('README.rst')
           + '\n\n' +
           read('CHANGES.rst')
-          ),
-      keywords = "zope cache",
-      classifiers = [
+      ),
+      keywords="zope cache",
+      classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Intended Audience :: Developers',
@@ -55,29 +45,30 @@ setup(name = 'zope.ramcache',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
-          ],
+      ],
       url='https://github.com/zopefoundation/zope.ramcache',
       license='ZPL 2.1',
       packages=find_packages('src'),
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       namespace_packages=['zope'],
-      install_requires = [
+      install_requires=[
           'persistent',
           'setuptools',
           'zope.interface',
           'zope.location',
-          'zope.testing',
-          ],
-      tests_require = ['zope.testrunner'],
-      test_suite = '__main__.alltests',
-      include_package_data = True,
-      zip_safe = False,
-      )
+      ],
+      tests_require=TESTS_REQUIRE,
+      extras_require={
+          'test': TESTS_REQUIRE,
+      },
+      include_package_data=True,
+      zip_safe=False,
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,2 +1,1 @@
-# this is a namespace package
-import pkg_resources; pkg_resources.declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/ramcache/tests/test_icache.py
+++ b/src/zope/ramcache/tests/test_icache.py
@@ -13,16 +13,19 @@
 ##############################################################################
 """Unit tests for ICache interface
 """
-from unittest import TestSuite, main
+import unittest
 from zope.interface.verify import verifyObject
 
 from zope.ramcache.interfaces import ICache
 
 
-class BaseICacheTest(object):
+class BaseICacheTest(unittest.TestCase):
     """Base class for ICache unit tests.  Subclasses should provide a
     _Test__new() method that returns a new empty cache object.
     """
+
+    def _Test__new(self):
+        raise unittest.SkipTest("Subclass must define")
 
     def testVerifyICache(self):
         # Verify that the object implements ICache
@@ -34,22 +37,22 @@ class BaseICacheTest(object):
         ob = "obj"
         data = "data"
         marker = []
-        self.assertFalse(cache.query(ob, None, default=marker) is not marker,
-                    "empty cache should not contain anything")
+        self.assertIs(cache.query(ob, None, default=marker), marker,
+                      "empty cache should not contain anything")
 
         cache.set(data, ob, key={'id': 35})
         self.assertEqual(cache.query(ob, {'id': 35}), data,
-                    "should return cached result")
-        self.assertFalse(cache.query(ob, {'id': 33}, default=marker)
-                            is not marker,
-                    "should not return cached result for a different key")
+                         "should return cached result")
+        self.assertIs(cache.query(ob, {'id': 33}, default=marker),
+                      marker,
+                      "should not return cached result for a different key")
 
         cache.invalidate(ob, {"id": 33})
         self.assertEqual(cache.query(ob, {'id': 35}), data,
-                          "should return cached result")
-        self.assertFalse(cache.query(ob, {'id': 33}, default=marker)
-                            is not marker,
-                    "should not return cached result after invalidate")
+                         "should return cached result")
+        self.assertIs(cache.query(ob, {'id': 33}, default=marker),
+                      marker,
+                      "should not return cached result after invalidate")
 
     def testInvalidateAll(self):
         cache = self._Test__new()
@@ -60,19 +63,11 @@ class BaseICacheTest(object):
         cache.set("data3", ob2, key={'foo': 2})
         cache.invalidateAll()
         marker = []
-        self.assertFalse(cache.query(ob1, default=marker) is not marker,
-                    "should not return cached result after invalidateAll")
-        self.assertFalse(cache.query(ob2, {'foo': 1}, default=marker)
-                            is not marker,
-                    "should not return cached result after invalidateAll")
-        self.assertFalse(cache.query(ob2, {'foo': 2}, default=marker)
-                            is not marker,
-                    "should not return cached result after invalidateAll")
-
-
-def test_suite():
-    return TestSuite((
-        ))
-
-if __name__=='__main__':
-    main(defaultTest='test_suite')
+        self.assertIs(cache.query(ob1, default=marker), marker,
+                      "should not return cached result after invalidateAll")
+        self.assertIs(cache.query(ob2, {'foo': 1}, default=marker),
+                      marker,
+                      "should not return cached result after invalidateAll")
+        self.assertIs(cache.query(ob2, {'foo': 2}, default=marker),
+                      marker,
+                      "should not return cached result after invalidateAll")

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,20 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3
+   py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src []
 deps =
-    persistent
-    zope.interface
-    zope.location
-    zope.testing
-    zope.testrunner
+    .[test]
+
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python3.6
+commands =
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report --fail-under=100
+deps =
+    {[testenv]deps}
+    coverage


### PR DESCRIPTION
- Badges
- Add more info to README.rst
- zope.testrunner for NS path issues.
- 100% coverage
  - Enable coveralls and a tox environment
  - Use ``with`` to replace ``try/finally`` for simpler code that uses
    fewer lines.
- Whitespace cleanup.
- Modern test assertion methods.