### PR TITLE
Fix issue #1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@
 
 - Test PyPy3 on Travis CI.
 
+- Stop requiring all values to support pickling in order to get
+  statistics. Instead, return ``False`` for the size if such a value
+  is found. Fixes `issue 1 <https://github.com/zopefoundation/zope.ramcache/issues/1>`_.
+
 2.1.0 (2014-12-29)
 ==================
 

--- a/src/zope/ramcache/interfaces/ram.py
+++ b/src/zope/ramcache/interfaces/ram.py
@@ -34,9 +34,16 @@ class IRAMCache(ICache):
         """Reports on the contents of a cache.
 
         The returned value is a sequence of dictionaries with the
-        following keys:
+        following (string) keys:
 
-          `path`, `hits`, `misses`, `size`, `entries`
+          - ``path``: The object being cached.
+          - ``hits``: How many times this path (for all its keys)
+            has been looked up.
+          - ``misses``: How many misses there have been for this path
+            and all its keys.
+          - ``size``: An integer approximating the RAM usage for this path
+            (only available if all values can be pickled; otherwise ``False``)
+          - ``entries``: How many total keys there are for this path.
         """
 
     def update(maxEntries, maxAge, cleanupInterval):


### PR DESCRIPTION
Catch exceptions pickling items getting stats.

Also eliminate several copies (on Python 2) and some extraneous dict lookups (on all versions).

Currently based on #4, only the tip commit is relevant.

Fixes #1