### PR TITLE
Use an object with __slots__ instead of a list for data storage. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@
   statistics. Instead, return ``False`` for the size if such a value
   is found. Fixes `issue 1 <https://github.com/zopefoundation/zope.ramcache/issues/1>`_.
 
+- Change the internal storage format of the RAM cache to require less
+  memory and be easier to maintain.
+
 2.1.0 (2014-12-29)
 ==================
 

--- a/src/zope/ramcache/tests/test_ramcache.py
+++ b/src/zope/ramcache/tests/test_ramcache.py
@@ -27,11 +27,11 @@ from zope.ramcache.tests.test_icache import BaseICacheTest
 from zope.ramcache.interfaces import ICache
 from zope.ramcache.interfaces.ram import IRAMCache
 
-def _data(values):
+def _data(value, ctime, access_count):
     from zope.ramcache.ram import _StorageData
-    data = _StorageData(values[0])
-    data.ctime = values[1]
-    data.access_count = values[2]
+    data = _StorageData(value)
+    data.ctime = ctime
+    data.access_count = access_count
     return data
 
 class TestRAMCache(CleanUp,
@@ -206,7 +206,7 @@ class TestStorage(unittest.TestCase):
         value = 'yes'
         timestamp = time()
 
-        s._data = {object: {key: _data([value, timestamp, 1])}}
+        s._data = {object: {key: _data(value, timestamp, 1)}}
         self.assertEqual(s.getEntry(object, key), value, 'got wrong value')
 
         self.assertEqual(s._data[object][key].access_count, 2,
@@ -252,7 +252,7 @@ class TestStorage(unittest.TestCase):
         timestamp = s._data[object][key].ctime
         self.assertTrue(t1 <= timestamp <= t2, 'wrong timestamp')
 
-        self.assertEqual(s._data, {object: {key: _data([value, timestamp, 0])}},
+        self.assertEqual(s._data, {object: {key: _data(value, timestamp, 0)}},
                          'stored data incorrectly')
 
         s._data[object][key].ctime = time() - 400
@@ -261,7 +261,7 @@ class TestStorage(unittest.TestCase):
         s.setEntry(object, key2, value)
 
         timestamp = s._data[object][key2].ctime
-        self.assertEqual(s._data, {object: {key2: _data([value, timestamp, 0])}},
+        self.assertEqual(s._data, {object: {key2: _data(value, timestamp, 0)}},
                          'cleanup not called')
 
     def test_set_get(self):
@@ -281,22 +281,22 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         value = 'yes'
         ts = time()
-        s._data = {object:  {key: _data([value, ts, 0]),
-                             key2: _data([value, ts, 0])},
-                   object2: {key: _data([value, ts, 0])}}
+        s._data = {object:  {key: _data(value, ts, 0),
+                             key2: _data(value, ts, 0)},
+                   object2: {key: _data(value, ts, 0)}}
         s._misses[object] = 42
         s._do_invalidate(object)
-        self.assertEqual(s._data, {object2: {key: _data([value, ts, 0])}},
+        self.assertEqual(s._data, {object2: {key: _data(value, ts, 0)}},
                          'invalidation failed')
         self.assertEqual(s._misses[object], 0, "misses counter not cleared")
 
-        s._data = {object:  {key: _data([value, ts, 0]),
-                             key2: _data([value, ts, 0])},
-                   object2: {key: _data([value, ts, 0])}}
+        s._data = {object:  {key: _data(value, ts, 0),
+                             key2: _data(value, ts, 0)},
+                   object2: {key: _data(value, ts, 0)}}
         s._do_invalidate(object, key2)
         self.assertEqual(s._data,
-                         {object:  {key: _data([value, ts, 0])},
-                          object2: {key: _data([value, ts, 0])}},
+                         {object:  {key: _data(value, ts, 0)},
+                          object2: {key: _data(value, ts, 0)}},
                          'invalidation of one key failed')
 
     def test_invalidate(self):
@@ -307,9 +307,9 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         value = 'yes'
         ts = time()
-        s._data = {object:  {key: _data([value, ts, 0]),
-                             key2: _data([value, ts, 0])},
-                   object2: {key: _data([value, ts, 0])}}
+        s._data = {object:  {key: _data(value, ts, 0),
+                             key2: _data(value, ts, 0)},
+                   object2: {key: _data(value, ts, 0)}}
 
         s.writelock.acquire()
         try:
@@ -319,11 +319,11 @@ class TestStorage(unittest.TestCase):
         self.assertEqual(s._invalidate_queue, [(object, None)],
                          "nothing in the invalidation queue")
 
-        s._data = {object:  {key: _data([value, ts, 0]),
-                             key2: _data([value, ts, 0])},
-                   object2: {key: _data([value, ts, 0])}}
+        s._data = {object:  {key: _data(value, ts, 0),
+                             key2: _data(value, ts, 0)},
+                   object2: {key: _data(value, ts, 0)}}
         s.invalidate(object)
-        self.assertEqual(s._data, {object2: {key: _data([value, ts, 0])}},
+        self.assertEqual(s._data, {object2: {key: _data(value, ts, 0)}},
                          "not invalidated")
 
     def test_invalidate_queued(self):
@@ -336,15 +336,16 @@ class TestStorage(unittest.TestCase):
         value = 'yes'
         ts = time()
         s._data = {
-            object: {key: _data([value, ts, 0]),
-                     key2: _data([value, ts, 0])},
-            object2: {key: _data([value, ts, 0])},
+            object: {key: _data(value, ts, 0),
+                     key2: _data(value, ts, 0)},
+            object2: {key: _data(value, ts, 0)},
             object3: "foo"
         }
         s._invalidate_queue = [(object2, None), (object3, None)]
         s._invalidate_queued()
         self.assertEqual(s._data,
-                         {object: {key: _data([value, ts, 0]), key2: _data([value, ts, 0])}},
+                         {object: {key: _data(value, ts, 0),
+                                   key2: _data(value, ts, 0)}},
                          "failed to invalidate queued")
 
     def test_invalidateAll(self):
@@ -355,9 +356,9 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         value = 'yes'
         ts = time()
-        s._data = {object:  {key: _data([value, ts, 0]),
-                             key2: _data([value, ts, 0])},
-                   object2: {key: _data([value, ts, 0])}}
+        s._data = {object:  {key: _data(value, ts, 0),
+                             key2: _data(value, ts, 0)},
+                   object2: {key: _data(value, ts, 0)}}
         s._invalidate_queue = [(object, None)]
         s._misses = {object: 10, object2: 100}
         s.invalidateAll()
@@ -382,9 +383,9 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         value = 'yes'
         ts = time()
-        s._data = {object:  {key: _data([value, ts, 0]),
-                             key2: _data([value, ts, 0])},
-                   object2: {key: _data([value, ts, 0])}}
+        s._data = {object:  {key: _data(value, ts, 0),
+                             key2: _data(value, ts, 0)},
+                   object2: {key: _data(value, ts, 0)}}
         keys = sorted(s.getKeys(object))
         expected = sorted([key, key2])
         self.assertEqual(keys, expected, 'bad keys')
@@ -396,15 +397,15 @@ class TestStorage(unittest.TestCase):
         key = ('view', (), ('answer', 42))
         value = 'yes'
         timestamp = time()
-        s._data = {object:  {key: _data([value, timestamp-101, 2])},
-                   object2: {key: _data([value, timestamp-90, 0])}}
+        s._data = {object:  {key: _data(value, timestamp-101, 2)},
+                   object2: {key: _data(value, timestamp-90, 0)}}
         s.removeStaleEntries()
-        self.assertEqual(s._data, {object2: {key: _data([value, timestamp-90, 0])}},
+        self.assertEqual(s._data, {object2: {key: _data(value, timestamp-90, 0)}},
                          'stale records removed incorrectly')
 
         s = Storage(maxAge=0)
-        s._data = {object:  {key: _data([value, timestamp, 2])},
-                   object2: {key: _data([value, timestamp-90, 0])}}
+        s._data = {object:  {key: _data(value, timestamp, 2)},
+                   object2: {key: _data(value, timestamp-90, 0)}}
         d = s._data.copy()
         s.removeStaleEntries()
         self.assertEqual(s._data, d, 'records removed when maxAge == 0')
@@ -423,25 +424,25 @@ class TestStorage(unittest.TestCase):
         key3 = ('view3', (), ('answer', 42))
         value = 'yes'
         timestamp = time()
-        s._data = {object:  {key1: _data([value, 1, 10]),
-                             key2: _data([value, 6, 5]),
-                             key3: _data([value, 2, 2])},
-                   object2: {key1: _data([value, 5, 2]),
-                             key2: _data([value, 3, 1]),
-                             key3: _data([value, 4, 1])}}
+        s._data = {object:  {key1: _data(value, 1, 10),
+                             key2: _data(value, 6, 5),
+                             key3: _data(value, 2, 2)},
+                   object2: {key1: _data(value, 5, 2),
+                             key2: _data(value, 3, 1),
+                             key3: _data(value, 4, 1)}}
         s.removeLeastAccessed()
         self.assertEqual(s._data,
-                         {object:  {key1: _data([value, 1, 0]),
-                                    key2: _data([value, 6, 0])}},
+                         {object:  {key1: _data(value, 1, 0),
+                                    key2: _data(value, 6, 0)}},
                          'least records removed incorrectly')
 
         s = Storage(maxEntries=6)
-        s._data = {object:  {key1: _data([value, timestamp, 10]),
-                             key2: _data([value, timestamp, 5]),
-                             key3: _data([value, timestamp, 2])},
-                   object2: {key1: _data([value, timestamp, 2]),
-                             key2: _data([value, timestamp, 1]),
-                             key3: _data([value, timestamp, 1])}}
+        s._data = {object:  {key1: _data(value, timestamp, 10),
+                             key2: _data(value, timestamp, 5),
+                             key3: _data(value, timestamp, 2)},
+                   object2: {key1: _data(value, timestamp, 2),
+                             key2: _data(value, timestamp, 1),
+                             key3: _data(value, timestamp, 1)}}
         c = s._data.copy()
         s.removeLeastAccessed()
         self.assertEqual(s._data, c, "modified list even though len < max")
@@ -454,20 +455,20 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         key3 = ('view3', (), ('answer', 42))
         value = 'yes'
-        s._data = {object:  {key1: _data([value, 1, 10]),
-                             key2: _data([value, 2, 5]),
-                             key3: _data([value, 3, 2])},
-                   object2: {key1: _data([value, 4, 2]),
-                             key2: _data([value, 5, 1]),
-                             key3: _data([value, 6, 1])}}
+        s._data = {object:  {key1: _data(value, 1, 10),
+                             key2: _data(value, 2, 5),
+                             key3: _data(value, 3, 2)},
+                   object2: {key1: _data(value, 4, 2),
+                             key2: _data(value, 5, 1),
+                             key3: _data(value, 6, 1)}}
         s._misses = {object: 4, object2: 2}
 
-        cleared = {object:  {key1: _data([value, 1, 0]),
-                             key2: _data([value, 2, 0]),
-                             key3: _data([value, 3, 0])},
-                   object2: {key1: _data([value, 4, 0]),
-                             key2: _data([value, 5, 0]),
-                             key3: _data([value, 6, 0])}}
+        cleared = {object:  {key1: _data(value, 1, 0),
+                             key2: _data(value, 2, 0),
+                             key3: _data(value, 3, 0)},
+                   object2: {key1: _data(value, 4, 0),
+                             key2: _data(value, 5, 0),
+                             key3: _data(value, 6, 0)}}
         clearMisses = {}
 
         s._clearAccessCounters()
@@ -482,12 +483,12 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         key3 = ('view3', (), ('answer', 42))
         value = 'yes'
-        s._data = {object:  {key1: _data([value, 1, 10]),
-                             key2: _data([value, 2, 5]),
-                             key3: _data([value, 3, 2])},
-                   object2: {key1: _data([value, 4, 2]),
-                             key2: _data([value, 5, 1]),
-                             key3: _data([value, 6, 1])}}
+        s._data = {object:  {key1: _data(value, 1, 10),
+                             key2: _data(value, 2, 5),
+                             key3: _data(value, 3, 2)},
+                   object2: {key1: _data(value, 4, 2),
+                             key2: _data(value, 5, 1),
+                             key3: _data(value, 6, 1)}}
         s._misses = {object: 11, object2: 42}
         len1 = len(dumps(s._data[object]))
         len2 = len(dumps(s._data[object2]))

--- a/src/zope/ramcache/tests/test_ramcache.py
+++ b/src/zope/ramcache/tests/test_ramcache.py
@@ -27,6 +27,12 @@ from zope.ramcache.tests.test_icache import BaseICacheTest
 from zope.ramcache.interfaces import ICache
 from zope.ramcache.interfaces.ram import IRAMCache
 
+def _data(values):
+    from zope.ramcache.ram import _StorageData
+    data = _StorageData(values[0])
+    data.ctime = values[1]
+    data.access_count = values[2]
+    return data
 
 class TestRAMCache(CleanUp,
                    BaseICacheTest,
@@ -200,10 +206,10 @@ class TestStorage(unittest.TestCase):
         value = 'yes'
         timestamp = time()
 
-        s._data = {object: {key: [value, timestamp, 1]}}
+        s._data = {object: {key: _data([value, timestamp, 1])}}
         self.assertEqual(s.getEntry(object, key), value, 'got wrong value')
 
-        self.assertEqual(s._data[object][key][2], 2,
+        self.assertEqual(s._data[object][key].access_count, 2,
                          'access count not updated')
 
         # See if _misses are updated
@@ -227,7 +233,7 @@ class TestStorage(unittest.TestCase):
 
         s.setEntry(object, key, value)
 
-        s._data[object][key][1] = time() - 400
+        s._data[object][key].ctime = time() - 400
         s.lastCleanup = time() - 400
 
         self.assertRaises(KeyError, s.getEntry, object, key)
@@ -243,19 +249,19 @@ class TestStorage(unittest.TestCase):
         s.setEntry(object, key, value)
         t2 = time()
 
-        timestamp = s._data[object][key][1]
+        timestamp = s._data[object][key].ctime
         self.assertTrue(t1 <= timestamp <= t2, 'wrong timestamp')
 
-        self.assertEqual(s._data, {object: {key: [value, timestamp, 0]}},
+        self.assertEqual(s._data, {object: {key: _data([value, timestamp, 0])}},
                          'stored data incorrectly')
 
-        s._data[object][key][1] = time() - 400
+        s._data[object][key].ctime = time() - 400
         s.lastCleanup = time() - 400
 
         s.setEntry(object, key2, value)
 
-        timestamp = s._data[object][key2][1]
-        self.assertEqual(s._data, {object: {key2: [value, timestamp, 0]}},
+        timestamp = s._data[object][key2].ctime
+        self.assertEqual(s._data, {object: {key2: _data([value, timestamp, 0])}},
                          'cleanup not called')
 
     def test_set_get(self):
@@ -275,22 +281,22 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         value = 'yes'
         ts = time()
-        s._data = {object:  {key: [value, ts, 0],
-                             key2: [value, ts, 0]},
-                   object2: {key: [value, ts, 0]}}
+        s._data = {object:  {key: _data([value, ts, 0]),
+                             key2: _data([value, ts, 0])},
+                   object2: {key: _data([value, ts, 0])}}
         s._misses[object] = 42
         s._do_invalidate(object)
-        self.assertEqual(s._data, {object2: {key: [value, ts, 0]}},
+        self.assertEqual(s._data, {object2: {key: _data([value, ts, 0])}},
                          'invalidation failed')
         self.assertEqual(s._misses[object], 0, "misses counter not cleared")
 
-        s._data = {object:  {key: [value, ts, 0],
-                             key2: [value, ts, 0]},
-                   object2: {key: [value, ts, 0]}}
+        s._data = {object:  {key: _data([value, ts, 0]),
+                             key2: _data([value, ts, 0])},
+                   object2: {key: _data([value, ts, 0])}}
         s._do_invalidate(object, key2)
         self.assertEqual(s._data,
-                         {object:  {key: [value, ts, 0]},
-                          object2: {key: [value, ts, 0]}},
+                         {object:  {key: _data([value, ts, 0])},
+                          object2: {key: _data([value, ts, 0])}},
                          'invalidation of one key failed')
 
     def test_invalidate(self):
@@ -301,9 +307,9 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         value = 'yes'
         ts = time()
-        s._data = {object:  {key: [value, ts, 0],
-                             key2: [value, ts, 0]},
-                   object2: {key: [value, ts, 0]}}
+        s._data = {object:  {key: _data([value, ts, 0]),
+                             key2: _data([value, ts, 0])},
+                   object2: {key: _data([value, ts, 0])}}
 
         s.writelock.acquire()
         try:
@@ -313,11 +319,11 @@ class TestStorage(unittest.TestCase):
         self.assertEqual(s._invalidate_queue, [(object, None)],
                          "nothing in the invalidation queue")
 
-        s._data = {object:  {key: [value, ts, 0],
-                             key2: [value, ts, 0]},
-                   object2: {key: [value, ts, 0]}}
+        s._data = {object:  {key: _data([value, ts, 0]),
+                             key2: _data([value, ts, 0])},
+                   object2: {key: _data([value, ts, 0])}}
         s.invalidate(object)
-        self.assertEqual(s._data, {object2: {key: [value, ts, 0]}},
+        self.assertEqual(s._data, {object2: {key: _data([value, ts, 0])}},
                          "not invalidated")
 
     def test_invalidate_queued(self):
@@ -330,15 +336,15 @@ class TestStorage(unittest.TestCase):
         value = 'yes'
         ts = time()
         s._data = {
-            object: {key: [value, ts, 0],
-                     key2: [value, ts, 0]},
-            object2: {key: [value, ts, 0]},
+            object: {key: _data([value, ts, 0]),
+                     key2: _data([value, ts, 0])},
+            object2: {key: _data([value, ts, 0])},
             object3: "foo"
         }
         s._invalidate_queue = [(object2, None), (object3, None)]
         s._invalidate_queued()
         self.assertEqual(s._data,
-                         {object: {key: [value, ts, 0], key2: [value, ts, 0]}},
+                         {object: {key: _data([value, ts, 0]), key2: _data([value, ts, 0])}},
                          "failed to invalidate queued")
 
     def test_invalidateAll(self):
@@ -349,9 +355,9 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         value = 'yes'
         ts = time()
-        s._data = {object:  {key: [value, ts, 0],
-                             key2: [value, ts, 0]},
-                   object2: {key: [value, ts, 0]}}
+        s._data = {object:  {key: _data([value, ts, 0]),
+                             key2: _data([value, ts, 0])},
+                   object2: {key: _data([value, ts, 0])}}
         s._invalidate_queue = [(object, None)]
         s._misses = {object: 10, object2: 100}
         s.invalidateAll()
@@ -376,9 +382,9 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         value = 'yes'
         ts = time()
-        s._data = {object:  {key: [value, ts, 0],
-                             key2: [value, ts, 0]},
-                   object2: {key: [value, ts, 0]}}
+        s._data = {object:  {key: _data([value, ts, 0]),
+                             key2: _data([value, ts, 0])},
+                   object2: {key: _data([value, ts, 0])}}
         keys = sorted(s.getKeys(object))
         expected = sorted([key, key2])
         self.assertEqual(keys, expected, 'bad keys')
@@ -390,15 +396,15 @@ class TestStorage(unittest.TestCase):
         key = ('view', (), ('answer', 42))
         value = 'yes'
         timestamp = time()
-        s._data = {object:  {key: [value, timestamp-101, 2]},
-                   object2: {key: [value, timestamp-90, 0]}}
+        s._data = {object:  {key: _data([value, timestamp-101, 2])},
+                   object2: {key: _data([value, timestamp-90, 0])}}
         s.removeStaleEntries()
-        self.assertEqual(s._data, {object2: {key: [value, timestamp-90, 0]}},
+        self.assertEqual(s._data, {object2: {key: _data([value, timestamp-90, 0])}},
                          'stale records removed incorrectly')
 
         s = Storage(maxAge=0)
-        s._data = {object:  {key: [value, timestamp, 2]},
-                   object2: {key: [value, timestamp-90, 0]}}
+        s._data = {object:  {key: _data([value, timestamp, 2])},
+                   object2: {key: _data([value, timestamp-90, 0])}}
         d = s._data.copy()
         s.removeStaleEntries()
         self.assertEqual(s._data, d, 'records removed when maxAge == 0')
@@ -417,25 +423,25 @@ class TestStorage(unittest.TestCase):
         key3 = ('view3', (), ('answer', 42))
         value = 'yes'
         timestamp = time()
-        s._data = {object:  {key1: [value, 1, 10],
-                             key2: [value, 6, 5],
-                             key3: [value, 2, 2]},
-                   object2: {key1: [value, 5, 2],
-                             key2: [value, 3, 1],
-                             key3: [value, 4, 1]}}
+        s._data = {object:  {key1: _data([value, 1, 10]),
+                             key2: _data([value, 6, 5]),
+                             key3: _data([value, 2, 2])},
+                   object2: {key1: _data([value, 5, 2]),
+                             key2: _data([value, 3, 1]),
+                             key3: _data([value, 4, 1])}}
         s.removeLeastAccessed()
         self.assertEqual(s._data,
-                         {object:  {key1: [value, 1, 0],
-                                    key2: [value, 6, 0]}},
+                         {object:  {key1: _data([value, 1, 0]),
+                                    key2: _data([value, 6, 0])}},
                          'least records removed incorrectly')
 
         s = Storage(maxEntries=6)
-        s._data = {object:  {key1: [value, timestamp, 10],
-                             key2: [value, timestamp, 5],
-                             key3: [value, timestamp, 2]},
-                   object2: {key1: [value, timestamp, 2],
-                             key2: [value, timestamp, 1],
-                             key3: [value, timestamp, 1]}}
+        s._data = {object:  {key1: _data([value, timestamp, 10]),
+                             key2: _data([value, timestamp, 5]),
+                             key3: _data([value, timestamp, 2])},
+                   object2: {key1: _data([value, timestamp, 2]),
+                             key2: _data([value, timestamp, 1]),
+                             key3: _data([value, timestamp, 1])}}
         c = s._data.copy()
         s.removeLeastAccessed()
         self.assertEqual(s._data, c, "modified list even though len < max")
@@ -448,20 +454,20 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         key3 = ('view3', (), ('answer', 42))
         value = 'yes'
-        s._data = {object:  {key1: [value, 1, 10],
-                             key2: [value, 2, 5],
-                             key3: [value, 3, 2]},
-                   object2: {key1: [value, 4, 2],
-                             key2: [value, 5, 1],
-                             key3: [value, 6, 1]}}
+        s._data = {object:  {key1: _data([value, 1, 10]),
+                             key2: _data([value, 2, 5]),
+                             key3: _data([value, 3, 2])},
+                   object2: {key1: _data([value, 4, 2]),
+                             key2: _data([value, 5, 1]),
+                             key3: _data([value, 6, 1])}}
         s._misses = {object: 4, object2: 2}
 
-        cleared = {object:  {key1: [value, 1, 0],
-                             key2: [value, 2, 0],
-                             key3: [value, 3, 0]},
-                   object2: {key1: [value, 4, 0],
-                             key2: [value, 5, 0],
-                             key3: [value, 6, 0]}}
+        cleared = {object:  {key1: _data([value, 1, 0]),
+                             key2: _data([value, 2, 0]),
+                             key3: _data([value, 3, 0])},
+                   object2: {key1: _data([value, 4, 0]),
+                             key2: _data([value, 5, 0]),
+                             key3: _data([value, 6, 0])}}
         clearMisses = {}
 
         s._clearAccessCounters()
@@ -476,12 +482,12 @@ class TestStorage(unittest.TestCase):
         key2 = ('view2', (), ('answer', 42))
         key3 = ('view3', (), ('answer', 42))
         value = 'yes'
-        s._data = {object:  {key1: [value, 1, 10],
-                             key2: [value, 2, 5],
-                             key3: [value, 3, 2]},
-                   object2: {key1: [value, 4, 2],
-                             key2: [value, 5, 1],
-                             key3: [value, 6, 1]}}
+        s._data = {object:  {key1: _data([value, 1, 10]),
+                             key2: _data([value, 2, 5]),
+                             key3: _data([value, 3, 2])},
+                   object2: {key1: _data([value, 4, 2]),
+                             key2: _data([value, 5, 1]),
+                             key3: _data([value, 6, 1])}}
         s._misses = {object: 11, object2: 42}
         len1 = len(dumps(s._data[object]))
         len2 = len(dumps(s._data[object2]))


### PR DESCRIPTION
This is smaller than a 3-item list on all checked versions of Python. 

It has the same access time for indexes versus attributes on all checked versions of Python.  

It may be somewhat slower to initially construct (its hard to benchmark list construction because of the internal list cache).

The primary reason to use it though, is code readability

This is currently based on #5, only the tip commit is relevant.


